### PR TITLE
Save and Read remoteConfig from DataStore

### DIFF
--- a/app/src/main/java/com/carlostorres/wordsgame/game/data/repository/DataStoreOperationsImpl.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/data/repository/DataStoreOperationsImpl.kt
@@ -10,6 +10,7 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.carlostorres.wordsgame.game.data.repository.DataStoreOperationsImpl.PreferencesKeys.canAccessToAppKey
 import com.carlostorres.wordsgame.game.data.repository.DataStoreOperationsImpl.PreferencesKeys.instructionsKey
 import com.carlostorres.wordsgame.game.domain.repository.DataStoreOperations
 import com.carlostorres.wordsgame.utils.Constants.EASY_GAMES_PLAYED_KEY
@@ -45,6 +46,8 @@ class DataStoreOperationsImpl @Inject constructor(
         val normalGamesPlayedKey = intPreferencesKey(name = NORMAL_GAMES_PLAYED_KEY)
         val hardGamesPlayedKey = intPreferencesKey(name = HARD_GAMES_PLAYED_KEY)
         val lastPlayedDateKey = stringPreferencesKey(name = LAST_PLAYED_DATE_KEY)
+
+        val canAccessToAppKey = booleanPreferencesKey(name = "can_access_to_app")
     }
 
     private val dataStore = context.dataStore
@@ -97,8 +100,30 @@ class DataStoreOperationsImpl @Inject constructor(
             }
             .map { preferences->
                 val onBoardingState = preferences[instructionsKey] ?: false
-                Log.d("Instructions", onBoardingState.toString())
+                Log.d("Datastore", "Instructions: $onBoardingState")
                 onBoardingState
+            }
+    }
+
+    override suspend fun saveCanAccessToApp(canAccess: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[canAccessToAppKey] = canAccess
+        }
+    }
+
+    override fun readCanAccessToApp(): Flow<Boolean> {
+        return dataStore.data
+            .catch { exception ->
+                if (exception is IOException) {
+                    emit(emptyPreferences())
+                }else{
+                    throw exception
+                }
+            }
+            .map { preferences ->
+                val canAccess = preferences[canAccessToAppKey] ?: true
+                Log.d("Datastore", "CanAccess: $canAccess")
+                canAccess
             }
     }
 

--- a/app/src/main/java/com/carlostorres/wordsgame/game/di/WordsModule.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/di/WordsModule.kt
@@ -19,11 +19,14 @@ import com.carlostorres.wordsgame.game.domain.repository.WordsRepository
 import com.carlostorres.wordsgame.game.domain.usecases.GameStatsUseCases
 import com.carlostorres.wordsgame.game.domain.usecases.words.GetRandomWordUseCase
 import com.carlostorres.wordsgame.game.domain.usecases.GameUseCases
+import com.carlostorres.wordsgame.game.domain.usecases.MenuUseCases
 import com.carlostorres.wordsgame.game.domain.usecases.stats.GetGameModeStatsUseCase
 import com.carlostorres.wordsgame.game.domain.usecases.OnboardingUseCases
 import com.carlostorres.wordsgame.game.domain.usecases.StatsUseCases
+import com.carlostorres.wordsgame.game.domain.usecases.settings.ReadAccessToAppDataStore
 import com.carlostorres.wordsgame.game.domain.usecases.stats.ReadDailyStatsUseCase
 import com.carlostorres.wordsgame.game.domain.usecases.settings.ReadInstructionsUseCase
+import com.carlostorres.wordsgame.game.domain.usecases.settings.SaveAccessToAppDataStore
 import com.carlostorres.wordsgame.game.domain.usecases.settings.SaveInstructionsUseCase
 import com.carlostorres.wordsgame.game.domain.usecases.stats.GetAllStatsUseCase
 import com.carlostorres.wordsgame.game.domain.usecases.stats.UpdateDailyStatsUseCase
@@ -133,7 +136,6 @@ object WordsModule {
         dataStoreOperations: DataStoreOperations
     ) : GameUseCases = GameUseCases(
         getRandomWordUseCase = GetRandomWordUseCase(wordsRepository),
-        canAccessToAppUseCase = CanAccessToAppUseCase(wordsRepository),
         updateDailyStatsUseCase = UpdateDailyStatsUseCase(dataStoreOperations),
         readDailyStatsUseCase = ReadDailyStatsUseCase(dataStoreOperations)
     )
@@ -193,5 +195,16 @@ object WordsModule {
     fun provideConnectivityObserver(
         @ApplicationContext context: Context
     ) : ConnectivityObserver = ConnectivityObserverImpl(context)
+
+    @Provides
+    @Singleton
+    fun provideMenuUseCases(
+        dataStoreOperations: DataStoreOperations,
+        repo: WordsRepository
+    ) : MenuUseCases = MenuUseCases(
+        canAccessToAppUseCase = CanAccessToAppUseCase(repo),
+        saveAccessToAppUseCase = SaveAccessToAppDataStore(dataStoreOperations),
+        readAccessToAppUseCase = ReadAccessToAppDataStore(dataStoreOperations)
+    )
 
 }

--- a/app/src/main/java/com/carlostorres/wordsgame/game/domain/repository/DataStoreOperations.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/domain/repository/DataStoreOperations.kt
@@ -13,4 +13,8 @@ interface DataStoreOperations {
 
     fun readInstructionsState(): Flow<Boolean>
 
+    suspend fun saveCanAccessToApp(canAccess: Boolean)
+
+    fun readCanAccessToApp(): Flow<Boolean>
+
 }

--- a/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/GameUseCases.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/GameUseCases.kt
@@ -7,7 +7,6 @@ import com.carlostorres.wordsgame.game.domain.usecases.words.GetRandomWordUseCas
 
 class GameUseCases(
     val getRandomWordUseCase: GetRandomWordUseCase,
-    val canAccessToAppUseCase: CanAccessToAppUseCase,
     val updateDailyStatsUseCase: UpdateDailyStatsUseCase,
     val readDailyStatsUseCase: ReadDailyStatsUseCase
 )

--- a/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/MenuUseCases.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/MenuUseCases.kt
@@ -1,0 +1,11 @@
+package com.carlostorres.wordsgame.game.domain.usecases
+
+import com.carlostorres.wordsgame.game.domain.usecases.settings.CanAccessToAppUseCase
+import com.carlostorres.wordsgame.game.domain.usecases.settings.ReadAccessToAppDataStore
+import com.carlostorres.wordsgame.game.domain.usecases.settings.SaveAccessToAppDataStore
+
+class MenuUseCases(
+    val canAccessToAppUseCase: CanAccessToAppUseCase,
+    val saveAccessToAppUseCase: SaveAccessToAppDataStore,
+    val readAccessToAppUseCase: ReadAccessToAppDataStore
+)

--- a/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/settings/ReadAccessToAppDataStore.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/settings/ReadAccessToAppDataStore.kt
@@ -1,0 +1,14 @@
+package com.carlostorres.wordsgame.game.domain.usecases.settings
+
+import com.carlostorres.wordsgame.game.domain.repository.DataStoreOperations
+import kotlinx.coroutines.flow.Flow
+
+class ReadAccessToAppDataStore(
+    private val dataStoreOperations: DataStoreOperations
+) {
+
+    operator fun invoke() : Flow<Boolean> {
+        return dataStoreOperations.readCanAccessToApp()
+    }
+
+}

--- a/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/settings/SaveAccessToAppDataStore.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/game/domain/usecases/settings/SaveAccessToAppDataStore.kt
@@ -1,0 +1,13 @@
+package com.carlostorres.wordsgame.game.domain.usecases.settings
+
+import com.carlostorres.wordsgame.game.domain.repository.DataStoreOperations
+
+class SaveAccessToAppDataStore(
+    private val dataStoreOperations: DataStoreOperations
+) {
+
+    suspend operator fun invoke(canAccess: Boolean) {
+        dataStoreOperations.saveCanAccessToApp(canAccess)
+    }
+
+}

--- a/app/src/main/java/com/carlostorres/wordsgame/menu/ui/MenuScreen.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/menu/ui/MenuScreen.kt
@@ -87,6 +87,7 @@ fun MenuScreen(
     val state = viewModel.state
 
     val userDailyStats = viewModel.dailyStats.collectAsState()
+    val canAccessToApp = viewModel.canAccessToApp.collectAsState()
 
     val colorText = if (isSystemInDarkTheme()) DarkTextGray else Color.Black
 
@@ -339,7 +340,7 @@ fun MenuScreen(
                     }
             )
 
-            if (state.blockVersion) {
+            if (state.blockVersion || !canAccessToApp.value) {
                 UpdateDialog()
             }
 

--- a/app/src/main/java/com/carlostorres/wordsgame/utils/Constants.kt
+++ b/app/src/main/java/com/carlostorres/wordsgame/utils/Constants.kt
@@ -6,6 +6,7 @@ object Constants {
     //const val BASE_URL = "https://clientes.api.greenborn.com.ar/"
     const val BASE_URL = "https://random-word-api.herokuapp.com/"
 
+    //region Datastore
     const val PREFERENCES_NAME = "wordsGame_preferences"
     const val INSTRUCTIONS_KEY = "instructions_seen"
     const val EASY_GAMES_PLAYED_KEY = "easy_games_played"
@@ -13,12 +14,19 @@ object Constants {
     const val HARD_GAMES_PLAYED_KEY = "hard_games_played"
     const val LAST_PLAYED_DATE_KEY = "last_played_date"
 
-    const val REMOTE_CONFIG_MIN_VERSION_KEY = "min_version"
+    const val CAN_ACCESS_TO_APP_KEY = "can_access_to_app"
+    //endregion
 
+    //region Firebase
+    const val REMOTE_CONFIG_MIN_VERSION_KEY = "min_version"
+    //endregion
+
+    //region Game
     const val EASY_WORD_LENGTH = 4
     const val NORMAL_WORD_LENGTH = 5
     const val HARD_WORD_LENGTH = 6
 
     const val NUMBER_OF_GAMES_ALLOWED = 5
+    //endregion
 
 }


### PR DESCRIPTION
Se lee la información de la aplicación desde remoteConfig, y se almacena en datastore para bloquear la version incluso offline 